### PR TITLE
fix: POST 요청 코드 제거 & a링크 GET 요청 시도

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,46 +16,6 @@ export default function SigninPage() {
   const [password, setPassword] = useState("")
   const [isFormValid, setIsFormValid] = useState(false)
 
-  // 카카오 로그인 버튼 클릭 시
-  const handleKakaoLogin = async () => {
-    try {
-      const res = await fetch(SIGNIN_KAKAO_API, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
-
-      if (res.ok) {
-        console.log(res.json())
-      } else {
-        alert("카카오 로그인 실패")
-      }
-    } catch (error) {
-      alert("카카오 로그인 요청 중 오류가 발생했습니다. 다시 시도하세요")
-    }
-  }
-
-  // 네이버 로그인 버튼 클릭 시
-  const handleNaverLogin = async () => {
-    try {
-      const res = await fetch(SIGNIN_NAVER_API, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
-
-      if (res.ok) {
-        console.log(res.json())
-      } else {
-        alert("네이버 로그인 실패")
-      }
-    } catch (error) {
-      alert("네이버 로그인 요청 중 오류가 발생했습니다. 다시 시도하세요")
-    }
-  }
-
   // 로그인 버튼 클릭 시
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -172,22 +132,22 @@ export default function SigninPage() {
               gap: 3,
             }}
           >
-            <Button onClick={handleKakaoLogin}>
+            <a href="https://yousayrun.store/auth/sign-in/kakao">
               <Image
                 src='/assets/kakao.png'
                 width={50}
                 height={50}
                 alt='Kakao Login'
               />
-            </Button>
-            <Button onClick={handleNaverLogin}>
+            </a>
+            <a href="https://yousayrun.store/auth/sign-in/naver">
               <Image
-                src='/assets/naver.png'
-                width={57}
-                height={57}
-                alt='Naver Login'
+              src='/assets/naver.png'
+              width={57}
+              height={57}
+              alt='Naver Login'
               />
-            </Button>
+            </a>
           </Box>
           <Box
             sx={{


### PR DESCRIPTION
기존 요청 코드 제거 후 이미지에 a링크 걸어 아래 주소로 get요청 보냈습니다.
https://yousayrun.store/auth/sign-in/kakao
백엔드 쪽에서 카카오 로그인 페이지로 넘겨주는 로직으로 다음 단계 이해하고 있습니다.
다음 시도는 프론트 쪽에서 카카오페이지로 파라미터 담아서 redirect 하는 방식으로
구현 시도해볼 예정입니다.