### PR TITLE
[#50] Implement error handler and toast context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/icons-material": "^5.15.5",
         "@mui/material": "^5.15.5",
         "@mui/material-nextjs": "^5.15.5",
+        "env-cmd": "^10.1.0",
         "next": "14.0.3",
         "react": "^18",
         "react-dom": "^18",
@@ -3886,7 +3887,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3953,7 +3953,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4278,6 +4277,21 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dependencies": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "bin": {
+        "env-cmd": "bin/env-cmd.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/error-ex": {
@@ -5813,8 +5827,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -6597,7 +6610,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7381,7 +7393,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -7393,7 +7404,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8384,7 +8394,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "env-cmd -f .env.dev next dev",
+    "local": "env-cmd -f .env.local next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -18,6 +19,7 @@
     "@mui/icons-material": "^5.15.5",
     "@mui/material": "^5.15.5",
     "@mui/material-nextjs": "^5.15.5",
+    "env-cmd": "^10.1.0",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,8 +1,46 @@
 "use client"
-export default function Error() {
+
+import { BuddyError, ErrorCode } from "@/utils/error"
+import { removeAccessToken } from "@/utils/server"
+import { Stack } from "@mui/material"
+
+const ErrorPage = ({
+  error,
+  reset,
+}: {
+  error: BuddyError & { digest?: string }
+  reset: () => void
+}) => {
+  const errorPage = (() => {
+    switch (error.code) {
+      case ErrorCode.UNAUTHORIZED_ERROR: {
+        removeAccessToken()
+        window.location.href = "/login"
+        return <LoadingPage />
+      }
+      case ErrorCode.GENERAL_LOGIC_ERROR:
+      default:
+        return <UnknownErrorPage />
+    }
+  })()
+
+  return errorPage
+}
+
+export default ErrorPage
+
+const LoadingPage = () => {
   return (
-    <>
-      <div>Error</div>
-    </>
+    <Stack direction='column' padding='2rem 1rem' height='100vh' pb='10vh'>
+      <div>loading..</div>
+    </Stack>
+  )
+}
+
+const UnknownErrorPage = () => {
+  return (
+    <Stack direction='column' padding='2rem 1rem' height='100vh' pb='10vh'>
+      <h1>알 수 없는 에러 발생</h1>
+    </Stack>
   )
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -22,6 +22,7 @@ import { theme } from "@/styles/theme"
 import { useMatchButton } from "../../hooks/useMatchButton"
 import { requestMatch } from "@/server/match"
 import { MatchRequest } from "@/types/server"
+import useToast from "@/hooks/useToast"
 
 export default function HomePage() {
   const { location, setLocation, size, setSize } = useMatchButton({})
@@ -52,20 +53,17 @@ export default function HomePage() {
 }
 
 const MatchButton = () => {
+  const { showErrorToast } = useToast()
   const GRADIENT_COLOR = `linear-gradient(95deg, #5E1EE7 13.09%, #7718C1 100%)`
-  // 버튼 클릭에서 에러 발생시 실행
-  const handleError = (msg?: string) => {
-    alert(msg ?? "match error!")
-    // window.location.href = "/"
-  }
-
   // 버튼 클릭 시 실행
   const handleClick = async () => {
     const body: MatchRequest = {
       location: "",
     }
     const response = await requestMatch(body)
-    console.log(response)
+    if (response.result !== "success") {
+      showErrorToast(response.code, { closeMS: 3000 })
+    }
   }
   return (
     <Button

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,12 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v13-appRouter"
 import RecoilRootProvider from "../providers/recoilRootProvider"
-import BottomNavbar from "@/components/common/BottomNavbar"
 import "@/styles/globals.css"
 import { ThemeProvider } from "@mui/material"
 import { theme } from "@/styles/theme"
 import { AuthBoundary } from "@/components/common/AuthBoundary"
+import React from "react"
+import PageLayout from "@/components/common/PageLayout"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -59,7 +60,7 @@ export default function RootLayout({
           <RecoilRootProvider>
             <ThemeProvider theme={theme}>
               <AuthBoundary>
-                {children} <BottomNavbar />
+                <PageLayout>{children}</PageLayout>
               </AuthBoundary>
             </ThemeProvider>
           </RecoilRootProvider>

--- a/src/components/common/PageLayout.tsx
+++ b/src/components/common/PageLayout.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { toastState } from "@/providers/toastAtom"
+import React from "react"
+import { useRecoilState } from "recoil"
+import BottomNavbar from "./BottomNavbar"
+import Toast from "./Toast"
+import { ToastType } from "@/types/toast"
+import { AnimationDirection } from "@/hooks/useAnimatedRender"
+import { getErrorCodeMsg } from "@/utils/error"
+
+interface PageProps {
+  children: React.ReactNode
+}
+
+const PageLayout = ({ children }: PageProps) => {
+  return (
+    <React.Fragment>
+      {children}
+      <BottomNavbar />
+      <ToastResolver />
+    </React.Fragment>
+  )
+}
+
+export default PageLayout
+
+const ToastResolver = () => {
+  const [toast, setToast] = useRecoilState(toastState)
+  const close = () => setToast(undefined)
+
+  switch (toast?.toastType) {
+    case ToastType.ERROR:
+      const message = getErrorCodeMsg(toast.payload)
+      return (
+        <Toast
+          message={message}
+          isOpen={true}
+          closeToast={close}
+          animationDirection={AnimationDirection.TOP_TO_BOTTOM}
+        />
+      )
+    default:
+      return null
+  }
+}

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,62 @@
+import { Icon, IconButton, Stack } from "@mui/material"
+import React from "react"
+import {
+  useAnimatedRender,
+  AnimationDirection,
+} from "@/hooks/useAnimatedRender"
+
+interface ToastProps {
+  message: string
+  isOpen: boolean
+  closeToast: () => void
+  animationDirection: AnimationDirection
+}
+
+const TOAST_ANIMATION_DURATION = 500
+
+const Toast = ({
+  message,
+  isOpen,
+  closeToast,
+  animationDirection,
+}: ToastProps) => {
+  const toastRef = React.createRef<HTMLDivElement>()
+
+  const onCloseClick = () => {
+    unmount()
+    setTimeout(() => {
+      closeToast()
+    }, TOAST_ANIMATION_DURATION)
+  }
+
+  const { unmount } = useAnimatedRender({
+    targetRef: toastRef,
+    direction: animationDirection,
+    transitionMs: TOAST_ANIMATION_DURATION,
+  })
+
+  return (
+    <Stack
+      ref={toastRef}
+      direction='row'
+      alignItems='center'
+      justifyContent='space-between'
+      sx={{
+        padding: "0px 10px",
+        borderRadius: 3,
+        marginLeft: "2.5%",
+        width: "95%",
+        height: 50,
+        boxShadow: "1px 1px 5px 1px rgba(0,0,0,0.2)",
+        backgroundColor: "white",
+      }}
+    >
+      {message}
+      <IconButton onClick={onCloseClick}>
+        <Icon>close</Icon>
+      </IconButton>
+    </Stack>
+  )
+}
+
+export default Toast

--- a/src/hooks/useAnimatedRender.ts
+++ b/src/hooks/useAnimatedRender.ts
@@ -1,0 +1,84 @@
+import { MS } from "@/types/common.types"
+import { useCallback, useLayoutEffect, useState } from "react"
+
+export enum AnimationDirection {
+  TOP_TO_BOTTOM = "TOP_TO_BOTTOM",
+  BOTTOM_TO_TOP = "BOTTOM_TO_TOP",
+}
+
+interface UseAnimatedRenderProps {
+  direction: AnimationDirection
+  targetRef: React.RefObject<HTMLElement>
+  transitionMs?: MS
+  transitionOption?: string
+  margin?: number
+}
+
+const DEFAULT_VERTICAL_MARGIN = 20
+export const useAnimatedRender = ({
+  direction,
+  targetRef,
+  transitionMs = 500,
+  transitionOption = "ease-in-out",
+  margin = DEFAULT_VERTICAL_MARGIN,
+}: UseAnimatedRenderProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(true)
+  const getOriginalPosition = useCallback(
+    (size: number) => {
+      switch (direction) {
+        case AnimationDirection.BOTTOM_TO_TOP:
+          return { position: "absolute", top: undefined, bottom: `-${size}px` }
+        case AnimationDirection.TOP_TO_BOTTOM:
+          return { position: "absolute", top: `-${size}px`, bottom: undefined }
+      }
+    },
+    [direction],
+  )
+
+  const getTransform = useCallback(
+    (heigt: number) => {
+      const translate = "translateY"
+      const sign =
+        (direction === AnimationDirection.BOTTOM_TO_TOP && isOpen) ||
+        (direction === AnimationDirection.TOP_TO_BOTTOM && !isOpen)
+          ? -1
+          : 1
+
+      return {
+        transform: `${translate}(${(heigt + margin) * sign}px)`,
+      }
+    },
+    [direction, isOpen, margin],
+  )
+
+  useLayoutEffect(() => {
+    if (targetRef.current === null) {
+      return
+    }
+
+    const { clientHeight: height } = targetRef.current
+    const transform = getTransform(height)
+    const position = getOriginalPosition(height)
+    const transitionDuration = transitionMs / 1000
+
+    const positionStyle: Partial<CSSStyleDeclaration> = {
+      ...position,
+      ...transform,
+      transitionDuration: `${transitionDuration}s`,
+      transitionTimingFunction: transitionOption,
+      transitionProperty: "transform",
+    }
+
+    Object.assign(targetRef.current.style, positionStyle)
+  }, [
+    getOriginalPosition,
+    getTransform,
+    targetRef,
+    transitionOption,
+    transitionMs,
+  ])
+
+  return {
+    unmount: () => setIsOpen(false),
+  }
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,25 @@
+import { toastState } from "@/providers/toastAtom"
+import { ToastProps, ToastType } from "@/types/toast"
+import { ErrorCode } from "@/utils/error"
+import { useRecoilState } from "recoil"
+
+const useToast = () => {
+  const [_, setToast] = useRecoilState(toastState)
+
+  const showErrorToast = (code: ErrorCode, props?: ToastProps) => {
+    setToast({
+      toastType: ToastType.ERROR,
+      payload: code,
+    })
+
+    if (props?.closeMS) {
+      setTimeout(() => {
+        setToast(undefined)
+      }, props.closeMS)
+    }
+  }
+
+  return { showErrorToast }
+}
+
+export default useToast

--- a/src/providers/toastAtom.ts
+++ b/src/providers/toastAtom.ts
@@ -1,0 +1,7 @@
+import { ToastState, ToastType } from "@/types/toast"
+import { atom } from "recoil"
+
+export const toastState = atom<ToastState<ToastType> | undefined>({
+  key: "toastState",
+  default: undefined,
+})

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,7 +7,7 @@ import {
 import request from "./fetch/request"
 import { getAccessToken, jsonifyResponse, setAccessToken } from "@/utils/server"
 import { ServerCode } from "./code"
-import { BuddyError, ErrorCode } from "@/utils/error"
+import { BuddyError, ErrorCode, handleError } from "@/utils/error"
 
 export const requestSignIn = async (
   body: SignInRequest,
@@ -25,8 +25,8 @@ export const requestSignIn = async (
     setAccessToken(result.token)
     return true
   } catch (error) {
-    const errorMsg = `request sign in fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request sign in fail:`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -42,7 +42,8 @@ export const requestSignUp = async (
     })
     return result.ok
   } catch (error) {
-    console.error(`request sign up fail: ${JSON.stringify(error)}`)
+    const errorMsg = `request sign up fail`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -57,8 +58,8 @@ export const requestSignOut = async (): Promise<boolean> => {
     }
     return true
   } catch (error) {
-    const errorMsg = `request sign out fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request sign out fail`
+    await handleError(error, errorMsg)
     return false
   }
 }
@@ -73,8 +74,8 @@ export const requestSendEmail = async (body: {
     })
     return result.ok
   } catch (error) {
-    const errorMsg = `request send email fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request send email fail`
+    await handleError(error, errorMsg)
     return false
   }
 }
@@ -90,8 +91,8 @@ export const requestVerify = async (body: {
     })
     return result.ok
   } catch (error) {
-    const errorMsg = `request email verificaiton fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request email verificaiton fail`
+    await handleError(error, errorMsg)
     return false
   }
 }
@@ -106,8 +107,8 @@ export const requestFindPassword = async (body: {
     })
     return result.ok
   } catch (error) {
-    const errorMsg = `request find password fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request find password fail`
+    await handleError(error, errorMsg)
     return undefined
   }
 }

--- a/src/server/fetch/request.ts
+++ b/src/server/fetch/request.ts
@@ -6,6 +6,7 @@ import {
 import { serverFetch } from "./server"
 import { clientFetch } from "./client"
 import { getAccessToken } from "@/utils/server"
+import { BuddyError, ErrorCode } from "@/utils/error"
 
 const DEFAULT_HEADER: HeadersInit = {
   "Content-Type": "application/json",
@@ -34,15 +35,8 @@ const request = async (
     return { ...init, headers: { ...init.headers, ...newHeader } }
   })()
 
-  const requesetUri: string = (() => {
-    if (uri.includes(getServerUri())) {
-      return uri
-    } else {
-      return prefix + uri
-    }
-  })()
-
-  console.debug(`[${init.method}] ${uri}`)
+  const requesetUri: string = prefix + uri
+  console.debug(`[${init.method}] ${requesetUri}`)
 
   if (process.env.NODE_ENV === "development") {
     const result: SeverFetchResponse = await serverFetch(requesetUri, newInit)

--- a/src/server/match.ts
+++ b/src/server/match.ts
@@ -1,21 +1,24 @@
-import { MatchRequest } from "@/types/server"
+import { BaseResponse, MatchRequest, MatchResponse } from "@/types/server"
 import request from "./fetch/request"
 import { jsonifyResponse } from "@/utils/server"
-import { ErrorCode } from "@/utils/error"
+import { BuddyError, ErrorCode, handleError } from "@/utils/error"
 
-export const requestMatch = async (body: MatchRequest): Promise<any> => {
+export const requestMatch = async (
+  body: MatchRequest,
+): Promise<MatchResponse> => {
   try {
-    const result = await request("/match", {
+    const result: MatchResponse = await request("/match", {
       method: "PUT",
     }).then(r => {
-      return jsonifyResponse<any>(r, ErrorCode.MATCH_GENERAL_ERROR)
+      return jsonifyResponse<MatchResponse>(r, ErrorCode.MATCH_GENERAL_ERROR)
     })
-    console.log(result)
+    if (result === undefined) {
+      throw new BuddyError(ErrorCode.MATCH_GENERAL_ERROR, "result is empty")
+    }
     return result
   } catch (error) {
-    const errorMsg = `request match fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
-    return undefined
+    const errorMsg = `request match fail`
+    return await handleError(error, errorMsg)
   }
 }
 
@@ -27,8 +30,8 @@ export const requestMatchJoin = async (): Promise<any> => {
     console.log(result)
     return result
   } catch (error) {
-    const errorMsg = `request match join fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request match join fail`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -41,8 +44,8 @@ export const requestMatchExit = async (): Promise<any> => {
     console.log(result)
     return result
   } catch (error) {
-    const errorMsg = `request match exit fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request match exit fail`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -55,8 +58,8 @@ export const requestMatchCancel = async (): Promise<any> => {
     console.log(result)
     return result
   } catch (error) {
-    const errorMsg = `request match cancel fail: ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `request match cancel fail`
+    await handleError(error, errorMsg)
     return undefined
   }
 }

--- a/src/server/user.ts
+++ b/src/server/user.ts
@@ -6,7 +6,7 @@ import {
   UserUpdateResponse,
 } from "@/types/server"
 import { User } from "@/providers/userAtom"
-import { ErrorCode } from "@/utils/error"
+import { ErrorCode, handleError } from "@/utils/error"
 
 export const requestUserInfo = async (): Promise<
   UserInfoResponse | undefined
@@ -18,8 +18,8 @@ export const requestUserInfo = async (): Promise<
 
     return result
   } catch (error) {
-    const errorMsg = `Failed to fetch user info ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to fetch user info`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -36,8 +36,8 @@ export const requestUserUpdate = async (
     )
     return result
   } catch (error) {
-    const errorMsg = `Failed to update user info ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to update user info`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -52,8 +52,8 @@ export const requestValidatePassword = async (body: {
     }).then(r => r.ok)
     return result
   } catch (error) {
-    const errorMsg = `Failed to validate password ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to validate password`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -68,8 +68,8 @@ export const requestUpdatePassword = async (body: {
     }).then(r => r.ok)
     return result
   } catch (error) {
-    const errorMsg = `Failed to update password ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to update password`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -81,7 +81,8 @@ export const requestUserWithdraw = async (): Promise<boolean | undefined> => {
     }).then(r => r.ok)
     return result
   } catch (error) {
-    const errorMsg = `Failed to withdraw user ${JSON.stringify(error)}`
+    const errorMsg = `Failed to withdraw user`
+    await handleError(error, errorMsg)
     console.error(errorMsg)
     return undefined
   }
@@ -95,8 +96,8 @@ export const requestProfile = async () => {
     console.log(result)
     return result
   } catch (error) {
-    const errorMsg = `Failed to get user profile ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to get user profile`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -112,8 +113,8 @@ export const requestProfileUpdate = async (
     console.log(result)
     return result
   } catch (error) {
-    const errorMsg = `Failed to update profile ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to update profile`
+    await handleError(error, errorMsg)
     return undefined
   }
 }
@@ -131,8 +132,8 @@ export const requestProfileImageUpload = async (
     }).then(r => r.ok)
     return result
   } catch (error) {
-    const errorMsg = `Failed to upload profile image ${JSON.stringify(error)}`
-    console.error(errorMsg)
+    const errorMsg = `Failed to upload profile image`
+    await handleError(error, errorMsg)
     return undefined
   }
 }

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -5,3 +5,5 @@ export type BottomNavbarItem = {
   text: string
   link: string
 }
+
+export type MS = number

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,3 +1,5 @@
+import { ErrorCode } from "@/utils/error"
+
 export interface FetchResponse {
   ok: boolean
   status: number
@@ -60,3 +62,10 @@ export interface UserUpdateResponse {
   userName: string
   gender: string
 }
+
+export interface ErrorResponse extends BaseResponse {
+  code: ErrorCode
+  result: "error"
+}
+
+export type MatchResponse = { result: "success" } | ErrorResponse

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -1,0 +1,19 @@
+import { ErrorCode } from "@/utils/error"
+import { MS } from "./common.types"
+
+export enum ToastType {
+  ERROR = "ERROR",
+}
+
+export interface ToastTypeState {
+  [ToastType.ERROR]: ErrorCode
+}
+
+export type ToastState<T extends ToastType> = {
+  toastType: T
+  payload: ToastTypeState[T]
+}
+
+export type ToastProps = {
+  closeMS?: MS
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,4 @@
+export const isObject = (value: unknown): value is Object => {
+  if (typeof value !== "object" || value === null) return false
+  return Object.getPrototypeOf(value) === Object.prototype
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,3 @@
+export const isDevelop = () => process.env.NODE_ENV === "development"
+export const isProd = () => process.env.NODE_ENV === "production"
+export const isTest = () => process.env.NODE_ENV === "test"

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,8 +1,7 @@
-export class BuddyError extends Error {
-  constructor(private readonly code: ErrorCode, message: string) {
-    super(message)
-  }
-}
+import request, { getServerUri } from "@/server/fetch/request"
+import { serverFetch } from "@/server/fetch/server"
+import { isObject } from "./common"
+import { ErrorResponse } from "@/types/server"
 
 export enum ErrorCode {
   UNAUTHORIZED_ERROR = "E01",
@@ -15,8 +14,66 @@ export enum ErrorCode {
   SIGN_OUT_ERROR = "E08",
   MATCH_GENERAL_ERROR = "E09",
   THUMBNAIL_ERROR = "E10",
+  NOT_FOUND_ERROR = "E11",
+  INTERNEL_SERVER_ERROR = "E12", // 500
 }
 
+export class BuddyError extends Error {
+  constructor(private readonly _code: ErrorCode, message: string) {
+    super(message)
+  }
+  public get code() {
+    return this._code
+  }
+}
+
+// error handler
+export const handleError = async (
+  error: unknown,
+  errorMsg?: string,
+): Promise<ErrorResponse> => {
+  console.error(errorMsg, JSON.stringify(error))
+  if (isReportTarget(error)) {
+    await reportError(error)
+  }
+
+  const errorCode = isBuddyError(error)
+    ? error.code
+    : ErrorCode.GENERAL_LOGIC_ERROR
+
+  return {
+    result: "error",
+    code: errorCode,
+    msg: getErrorCodeMsg(errorCode) + errorMsg,
+  }
+}
+
+const isReportTarget = (error: unknown): error is BuddyError | TypeError => {
+  const isBuddyError = error instanceof BuddyError
+  const isTypeError = error instanceof TypeError
+  return (isBuddyError && REPORT_ERROR.includes(error.code)) || isTypeError
+}
+
+const reportError = async (error: BuddyError | TypeError) => {
+  console.log("[REPORT ERROR]", JSON.stringify(error))
+
+  try {
+    const body = {
+      error: JSON.stringify(error),
+      buffer: "buffer",
+    }
+    console.log("body", JSON.stringify(body))
+
+    await serverFetch(`${getServerUri()}/error-report`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  } catch (error) {
+    console.error(`Error reporting failed:`, error)
+  }
+}
+
+// define if report target
 const ErrorMsg: Record<ErrorCode, string> = {
   [ErrorCode.UNAUTHORIZED_ERROR]: "권한이 없습니다.",
   [ErrorCode.NETWORK_ERROR]: "네트워크 오류가 발생했습니다.",
@@ -28,6 +85,25 @@ const ErrorMsg: Record<ErrorCode, string> = {
   [ErrorCode.SIGN_OUT_ERROR]: "로그아웃 중 오류가 발생했습니다.",
   [ErrorCode.MATCH_GENERAL_ERROR]: "오류가 발생했습니다.",
   [ErrorCode.THUMBNAIL_ERROR]: "링크 썸네일을 가져올 수 없습니다.",
+  [ErrorCode.NOT_FOUND_ERROR]: "페이지를 찾을 수 없습니다.",
+  [ErrorCode.INTERNEL_SERVER_ERROR]: "서버 오류가 발생했습니다.",
 }
 
+const REPORT_ERROR: ErrorCode[] = [
+  ErrorCode.NAVER_MAPS_ERROR,
+  ErrorCode.GOOGLE_MAPS_ERROR,
+  ErrorCode.GENERAL_LOGIC_ERROR,
+
+  ErrorCode.THUMBNAIL_ERROR,
+]
+
 export const getErrorCodeMsg = (code: ErrorCode) => ErrorMsg[code]
+
+// type guard
+export const isBuddyError = (error: unknown): error is BuddyError => {
+  if (!isObject(error) || !error.hasOwnProperty("code")) {
+    return false
+  }
+  const code = (error as BuddyError).code
+  return code !== undefined && code in ErrorCode
+}


### PR DESCRIPTION
### 1. 서버 환경 구분용 env 추가
* local 서버와 레거시 스프링 서버를 구분하기 위해 env로 local 을 추가하고, package.json을 수정합니다. env file은 [노션](https://www.notion.so/choose-kindness/831553ecb7d4494c99d8c9ec4cef2c7e?pvs=4#509149f88312471b9482990f20cb1f3c) 에 정리해뒀습니다.

### 2. 클라이언트 에러 핸들링
* fetch를 위해 여러 함수를 통과하는데.. requestMatch 와 같이 `request` prefix가 달린 함수들이 컴포넌트에서 사용하는 유틸입니다. 이 유틸에서만 try ... catch를 써서 에러 핸들링을 하고, 핸들링 결과가 컴포넌트로 전달되어야 하는 경우 (eg. 에러에 대한 UI 피드백이 있어야 하는 경우) 에는 ErrorResponse 타입으로 전달됩니다.
* 렌더링 과정에서 일어난 error의 경우 error boundary 로 떨어지고, root의 error.tsx에서 렌더링합니다.
* 온클릭 이벤트로부터 발생된 error의 경우 명시적으로 컴포넌트가 핸들링해야합니다. 이를 위해 각 request 유틸 함수에서 리턴된 ErrorResponse를 확인해서 toast를 띄울 수 있습니다. 


> Next.js 애플리케이션에서 React의 Error Boundary는 컴포넌트 트리의 어느 지점에서 발생한 JavaScript 에러를 캐치하여 로그를 기록하거나 사용자에게 폴백 UI를 보여주는데 사용됩니다. 기본적으로, Error Boundary는 렌더링 중, 생명주기 메서드에서 발생한 에러, 그리고 그 아래에 있는 컴포넌트 트리의 생성자(constructor) 내에서 발생한 에러를 캐치합니다.
> 
> 그러나, onClick 같은 이벤트 핸들러 내에서 발생한 에러는 자동으로 Error Boundary에 의해 캐치되지 않습니다. 이벤트 핸들러와 같은 비동기 코드에서 발생한 에러는 별도로 처리해야 합니다. (GPT)

* 에러 핸들링을 위해서는 일반 스트링이 아닌 ErrorCode를 사용합니다. 에러를 깔끔하게 관리할 수 있고 식별에 용이합니다.. toast, error boundary 모두 ErrorCode 기반으로 동작합니다. 다음 두 함수가 나름 주요(?) 함수인데 코드에 코멘트 달겠습니다.
    1. jsonifyResponse<T>: 응답 바디 파싱, 파싱 에러시 BuddyError throw
    2. handleError: 에러 핸들링, 리포팅 타겟인 경우 리포트, ErrorResponse 객체 생성과 반환

### 3. 토스트 컴포넌트 구현
* 에러 메시지를 토스트로 띄웁니다.
* 타입 구분해서.. 에러 메시지 말고도 다른 것들 띄울 수 있습니다.

어쩌다보니 PR에 포함된 변경이 많은데 가급적 분리하겠습니다..